### PR TITLE
fix: correct log message for empty transaction messages

### DIFF
--- a/blocksync/txns.go
+++ b/blocksync/txns.go
@@ -206,7 +206,7 @@ func StoreWasmTransaction(txn []interface{}, db *leveldb.DB, JsonAPI string) {
 			}
 
 			if len(txns.TxResponse.Tx.Body.Messages) == 0 {
-				logs.Log.Warn(fmt.Sprintf("Failed to unmarshal transaction: %s", err))
+				logs.Log.Warn("Transaction contains no messages")
 				time.Sleep(2 * time.Second)
 				continue
 			}


### PR DESCRIPTION
The previous log incorrectly indicated a failure to unmarshal the transaction when no messages were present. This commit changes the log to accurately state that the transaction contains no messages. 